### PR TITLE
fix: remove semicolon

### DIFF
--- a/main.go
+++ b/main.go
@@ -343,7 +343,7 @@ func waitForClusterOp(b *hb.Bot, actor string, cluster *cluster.Client, c *cid.C
 		finished := len(doneMap)
 
 		if done == finished && done >= localReplMax {
-			botMsg(actor, fmt.Sprintf("DONE: %s/ipfs/%s: reached %s in %d cluster peers.", gateway, c, target, done))
+			botMsg(actor, fmt.Sprintf("DONE: %s/ipfs/%s reached %s in %d cluster peers.", gateway, c, target, done))
 			return
 		}
 


### PR DESCRIPTION
This semicolon inhibits links on IRC from being clickable, as it is automatically parsed as part of the link by the webchat.freenode client. By removing it, people can click on the link directly in the chat. I do not think it adds anything substantially, so removing it should be trivial.